### PR TITLE
Replace lens with microlens-platform

### DIFF
--- a/mat-chalmers.cabal
+++ b/mat-chalmers.cabal
@@ -57,7 +57,7 @@ library
                , base >=4.7
                , css-text
                , http-conduit
-               , lens
+               , microlens-platform
                , lucid >= 2
                , old-locale
                , tagsoup

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -5,7 +5,7 @@
 
 module Config where
 
-import Control.Lens
+import Lens.Micro.Platform
 
 -- | Configuration record
 data Config = Config

--- a/src/M.hs
+++ b/src/M.hs
@@ -7,10 +7,10 @@ module M
   ) where
 
 import Control.Concurrent.MVar
-import Control.Lens
 import Data.IORef
 import Data.Thyme
 import Data.Thyme.Calendar.WeekDate
+import Lens.Micro.Platform
 
 import Config
 import M.Einstein

--- a/src/V.hs
+++ b/src/V.hs
@@ -5,12 +5,12 @@ module V
   , render
   ) where
 
-import Control.Lens ((&), (%~), both)
 import Data.FileEmbed
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.Builder as T
 import Data.Monoid
 import Data.Thyme
+import Lens.Micro.Platform ((&), (%~), both)
 import Lucid
 import System.Locale (defaultTimeLocale)
 import qualified Text.CSS.Parse as CSS


### PR DESCRIPTION
Lens.Micro.Platform is (at least for this use-case) a drop-in
replacement of Control.Lens without most of its dependencies.