### PR TITLE
Upgraded resolver to lts-13.0. The future is here.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.20
+resolver: lts-13.0
 packages:
   - "."
   - location: "wai-middleware-static-embedded"


### PR DESCRIPTION
The changes build on my computer. It takes some time though since GHC 8.6 is downloaded and installed.