### PR TITLE
Replace lens dependency in executable

### DIFF
--- a/mat-chalmers.cabal
+++ b/mat-chalmers.cabal
@@ -85,7 +85,7 @@ executable mat-chalmers
                , base >=4.7
                , bytestring
                , file-embed
-               , lens
+               , microlens-platform
                , mtl
                , scotty
                , wai-extra


### PR DESCRIPTION
When we replaced lens dependency with the much lighter
microlens-platform library we only updated the dependecies of the
library and not the executable. This commit updates the lens
dependency for the executable as well.