### PR TITLE
Replace lens dependency in executable

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -4,11 +4,11 @@
 module Main (main) where
 
 import           Control.Concurrent
-import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Trans (liftIO)
 import           Data.FileEmbed
 import           Data.IORef
+import           Lens.Micro.Platform
 import           Network.Wai.Middleware.RequestLogger
 import           Network.Wai.Middleware.StaticEmbedded
 import           System.Console.GetOpt

--- a/mat-chalmers.cabal
+++ b/mat-chalmers.cabal
@@ -85,7 +85,7 @@ executable mat-chalmers
                , base >=4.7
                , bytestring
                , file-embed
-               , lens
+               , microlens-platform
                , mtl
                , scotty
                , wai-extra


### PR DESCRIPTION
When we replaced lens dependency with the much lighter
microlens-platform library we only updated the dependecies of the
library and not the executable. This commit updates the lens
dependency for the executable as well.