### PR TITLE
Moved wai-middleware-static-embedded from submodule to dependency.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wai-middleware-static-embedded"]
-	path = wai-middleware-static-embedded
-	url = https://github.com/adamse/wai-middleware-static-embedded.git

--- a/mat-chalmers.cabal
+++ b/mat-chalmers.cabal
@@ -89,7 +89,7 @@ executable mat-chalmers
                , mtl
                , scotty
                , wai-extra
-               , wai-middleware-static-embedded
+               , wai-middleware-static-embedded == 0.1.0.0
 
   -- Base language which the package is written in.
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,6 @@
 resolver: lts-13.0
 packages:
   - "."
-  - location: "wai-middleware-static-embedded"
-    extra-dep: true
 extra-deps:
   - thyme-0.3.5.5
+  - wai-middleware-static-embedded-0.1.0.0@sha256:036b7823a5e69452d1fe1e270ef3d4988063caa5bb00b6dfc356e1c21b7433e3


### PR DESCRIPTION
 - wai-middleware-static-embedded is on Hackage, so we can install it
   using cabal instead of having it as a submodule.