### PR TITLE
Added logging to the fetching and parsing functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cabal-dev
 cabal.sandbox.config
 .stack-work/
 .*.swp
+*.log

--- a/mat-chalmers.cabal
+++ b/mat-chalmers.cabal
@@ -32,10 +32,13 @@ library
                , exceptions == 0.10.0
                , heredoc == 0.2.0.0
                , http-client
+               , logging-effect == 1.3.3
                , microlens-platform
                , lucid >= 2
                , mtl == 2.2.2
-               , old-locale
+               , old-locale == 1.0.0.7
+               , prettyprinter == 1.2.1
+               , safe == 0.3.17
                , text
                , bytestring
                , file-embed
@@ -51,8 +54,10 @@ executable mat-chalmers
                , file-embed
                , http-client-tls == 0.3.5.3
                , microlens-platform
+               , logging-effect == 1.3.3
                , mtl
                , scotty
+               , time == 1.8.0.2
                , wai-extra
                , wai-middleware-static-embedded == 0.1.0.0
   default-language: Haskell2010

--- a/mat-chalmers.cabal
+++ b/mat-chalmers.cabal
@@ -32,7 +32,7 @@ library
                , exceptions == 0.10.0
                , heredoc == 0.2.0.0
                , http-client
-               , logging-effect == 1.3.3
+               , logging-effect >= 1.3.2
                , microlens-platform
                , lucid >= 2
                , mtl == 2.2.2
@@ -54,7 +54,7 @@ executable mat-chalmers
                , file-embed
                , http-client-tls == 0.3.5.3
                , microlens-platform
-               , logging-effect == 1.3.3
+               , logging-effect
                , mtl
                , scotty
                , time == 1.8.0.2

--- a/shell.nix
+++ b/shell.nix
@@ -4,8 +4,11 @@ let
 
   inherit (nixpkgs) pkgs;
 
-  f = { mkDerivation, stdenv, haskellPackages
-      , wai-extra, wai-middleware-static-embedded
+  f = { mkDerivation, aeson, base, bytestring, css-text, errors
+      , exceptions, file-embed, heredoc, http-client, http-client-tls
+      , logging-effect, lucid, microlens-platform, mtl, old-locale
+      , prettyprinter, safe, scotty, stdenv, text, thyme, time, wai-extra
+      , wai-middleware-static-embedded
       }:
       mkDerivation {
         pname = "mat-chalmers";
@@ -15,25 +18,24 @@ let
         isExecutable = true;
         buildTools = [ haskellPackages.cabal-install ];
         enableSeparateDataOutput = true;
-        libraryHaskellDepends = with haskellPackages; [
-          aeson base bytestring css-text file-embed http-conduit lucid
-          old-locale microlens-platform old-locale tagsoup text thyme
+        libraryHaskellDepends = [
+          aeson base bytestring css-text errors exceptions file-embed heredoc
+          http-client logging-effect lucid microlens-platform mtl old-locale
+          prettyprinter safe text thyme
         ];
-        executableHaskellDepends = with haskellPackages; [
-          base bytestring file-embed lens mtl scotty wai-extra
+        executableHaskellDepends = [
+          base bytestring file-embed http-client-tls logging-effect
+          microlens-platform mtl scotty time wai-extra
           wai-middleware-static-embedded
         ];
         license = stdenv.lib.licenses.mit;
       };
-
-
 
   haskellPackages = if compiler == "default"
                        then pkgs.haskellPackages
                        else pkgs.haskell.packages.${compiler};
 
   variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
-  wai-middleware-static-embedded = pkgs.callPackage ./wai-middleware-static-embedded;
 
   drv = variant (haskellPackages.callPackage f {});
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -12,9 +12,10 @@ data Config = Config
   , _cNextDayHour :: !Int
   , _cInterval    :: !Int
   , _cPort        :: !Int
+  , _cLog         :: !String
   } deriving (Eq, Show)
 
 makeLenses ''Config
 
 defaultConfig :: Config
-defaultConfig = Config False 14 (1000000 * 60 * 30) 5007
+defaultConfig = Config False 14 (1000000 * 60 * 30) 5007 "mat.log"

--- a/src/Model/Karen.hs
+++ b/src/Model/Karen.hs
@@ -1,37 +1,32 @@
 module Model.Karen where
 
-import           Data.Aeson                               ( decode )
-import           Data.Aeson.Types                         ( parseMaybe )
+import           Data.Aeson                               ( eitherDecode )
+import           Data.Aeson.Types                         ( parseEither )
 import           Data.ByteString.Lazy                     ( ByteString )
+import           Data.Bifunctor                           ( first )
 import           Data.Maybe                               ( fromMaybe )
-import           Data.Text.Lazy                           ( Text )
+import           Data.Text.Lazy                           ( Text
+                                                          , pack
+                                                          )
 import           Data.Text.Lazy.Encoding                  ( decodeUtf8 )
 import           Data.Thyme                               ( Day )
 
-import           Model.Types                              ( NoMenu(..)
+import           Model.Types                              ( Menu
+                                                          , NoMenu(..)
                                                           , Restaurant(..)
                                                           )
 import           Model.KarenJSON
 
--- | Get a restaurant that kåren has.
-getKaren :: Day -> Text -> Text -> Maybe ByteString -> Restaurant
-getKaren weekday name menuUrl text =
-  Restaurant name menuUrl
-    . fromMaybe (Left (SomethingWrong (fmap decodeUtf8 text)))
-    $ do
-        text' <- text
-        val   <- decode text'
-        res   <- parseMaybe (parseMenuForDay weekday) val
-        return $ case res of
-          Nothing -> Left NoLunch
-          Just l  -> Right (concat l)
+-- | Parse a restaurant that Kåren has.
+getKaren :: Day -> ByteString -> Either NoMenu [Menu]
+getKaren weekday rawBS = maybe (Left NoLunch) (pure . pure) =<< first
+  (flip NMParseError rawBS)
+  (parseEither (parseMenuForDay weekday) =<< eitherDecode rawBS)
 
-getKarenToday :: Text -> Text -> Maybe ByteString -> Restaurant
-getKarenToday name menuUrl text =
-  Restaurant name menuUrl
-    . fromMaybe (Left (SomethingWrong (fmap decodeUtf8 text)))
-    $ do
-        text'  <- text
-        val    <- decode text'
-        (_, l) <- parseMaybe parseMenus val
-        return $ Right (concat l)
+-- | Parse today's menu for a restaurant that Kåren has.
+getKarenToday :: ByteString -> Either NoMenu [Menu]
+getKarenToday rawBS =
+  first (flip NMParseError rawBS)
+    $   fmap (concat . snd)
+    $   parseEither parseMenus
+    =<< eitherDecode rawBS

--- a/src/Model/Types.hs
+++ b/src/Model/Types.hs
@@ -1,48 +1,42 @@
-{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -- | Types and internal functions
 
 module Model.Types where
 
-import           Control.Monad.Catch                      ( MonadCatch
-                                                          , MonadThrow
-                                                          )
-import           Control.Monad.Reader                     ( MonadIO
-                                                          , MonadReader
-                                                          , ReaderT
-                                                          )
+import           Data.ByteString.Lazy                     ( ByteString )
 import           Data.Text.Lazy                           ( Text )
 import           Data.Thyme                               ( LocalTime )
-import           Network.HTTP.Client                      ( Manager )
+import           Network.HTTP.Client                      ( HttpException
+                                                          , Manager
+                                                          )
 
 import           Config                                   ( Config )
 
-
-newtype ClientT m r a = ClientT { runClientT :: ReaderT r m a }
-  deriving (Functor, Applicative, Monad, MonadCatch, MonadReader r, MonadIO, MonadThrow)
-
-data ClientContext = ClientContext { ccCfg :: Config, ccManager :: Manager }
-
-type Client = ClientT IO ClientContext
+data ClientContext = ClientContext
+  { ccCfg     :: Config
+  , ccManager :: Manager
+  }
 
 -- | What to pass to template.
 data View = View
   { restaurants :: [Restaurant]
   , day         :: Text
   , date        :: LocalTime
-  } deriving (Eq, Show)
+  } deriving (Show)
 
 -- | One pretty restaurant.
 data Restaurant = Restaurant
   { name :: Text
   , url  :: Text
   , menu :: Either NoMenu [Menu]
-  } deriving (Eq, Show)
+  } deriving (Show)
 
 data NoMenu
   = NoLunch
-  | SomethingWrong (Maybe Text)
-  deriving (Eq, Show)
+  | NMHttp HttpException
+  | NMParseError String ByteString -- ^ The parse error. The string we tried to parse.
+  deriving (Show)
 
 -- | Menu of a restaurant.
 data Menu = Menu Text Text

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -1,10 +1,23 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 module Util where
 
-import           Control.Exception                        ( handle )
-import           Control.Monad.Reader                     ( asks )
-import           Control.Monad.Trans                      ( liftIO )
+import           Control.Exception                        ( try )
+import           Control.Monad.Catch                      ( MonadCatch
+                                                          , MonadThrow
+                                                          )
+import           Control.Monad.Reader                     ( MonadReader
+                                                          , ReaderT
+                                                          , asks
+                                                          )
+import           Control.Monad.Trans                      ( MonadIO
+                                                          , liftIO
+                                                          )
+import           Data.Bifunctor                           ( bimap )
 import           Data.ByteString.Lazy                     ( ByteString )
-import           Data.Text.Lazy                           ( Text )
+import           Data.Text.Lazy                           ( Text
+                                                          , pack
+                                                          )
 import           Data.Text.Lazy.Encoding                  ( decodeUtf8 )
 import           Network.HTTP.Client                      ( HttpException
                                                           , Request
@@ -13,27 +26,35 @@ import           Network.HTTP.Client                      ( HttpException
                                                           , responseBody
                                                           )
 
-import           Model.Types                              ( Client(..)
-                                                          , ClientContext(..)
+import           Model.Types                              ( ClientContext(..)
+                                                          , Menu
+                                                          , NoMenu(..)
+                                                          , Restaurant(..)
                                                           )
 
 takeNext :: [a] -> [a]
 takeNext = take 1 . drop 1
 
-safeGet :: String -> Client (Maybe Text)
+safeGet
+  :: (MonadIO m, MonadReader ClientContext m, MonadThrow m)
+  => String
+  -> m (Either NoMenu Text)
 safeGet = (fmap . fmap) decodeUtf8 . safeGetBS
 
-safeBS :: Request -> Client (Maybe ByteString)
+safeBS
+  :: (MonadIO m, MonadReader ClientContext m, MonadThrow m)
+  => Request
+  -> m (Either NoMenu ByteString)
 safeBS r = do
   m <- asks ccManager
-  liftIO $ (fmap . fmap) responseBody (handle' (liftIO (httpLbs r m)))
+  liftIO (fmap (bimap NMHttp responseBody) (handle' (liftIO (httpLbs r m))))
 
-safeGetBS :: String -> Client (Maybe ByteString)
+safeGetBS
+  :: (MonadIO m, MonadReader ClientContext m, MonadThrow m)
+  => String
+  -> m (Either NoMenu ByteString)
 safeGetBS = (=<<) safeBS . parseRequest
 
 -- | Handler for HttpExceptions
-handle' :: IO a -> IO (Maybe a)
-handle' a = handle handler (fmap Just a)
- where
-  handler :: HttpException -> IO (Maybe a)
-  handler _ = return Nothing
+handle' :: IO a -> IO (Either HttpException a)
+handle' = try

--- a/src/View.hs
+++ b/src/View.hs
@@ -49,8 +49,8 @@ renderRest :: Restaurant -> Html ()
 renderRest Restaurant {..} = box_ $ do
   h2_ (toHtml name >> " " >> a_ [href_ (T.toStrict url)] "☛")
   ul_ [class_ "food-menu"] $ case menu of
-    Left NoLunch            -> li_ "No lunch this day!"
-    Left (SomethingWrong _) -> li_ "Something went wrong, " <> a_
+    Left NoLunch -> li_ "No lunch this day!"
+    Left _       -> li_ "Something went wrong, " <> a_
       [href_ $ T.toStrict "https://github.com/dtekcth/mat-chalmers/issues/new"]
       "please file an issue."
     Right menus -> mconcat (map renderMenu menus)


### PR DESCRIPTION
We implement logging to make it easier to use the data that caused an
error when debugging. We put the error together with the input data that
caused the error in the log file.

To do this I had to do code refactoring and feature implementations:

 - Added an option to the executable, to let the user set the filename
   of the logfile.
 - Rewrote all functions in the `Client` monad to mtl style.
 - Removed the `ClientT` monad transformer stack, it wasn't needed
   anymore when using mtl style.
 - Rewrote `getKaren` and `getKarenToday` to take a `ByteString` as
   argument and evaluate to `Either NoMenu [Menu]`
 - Added the `NMHttp` and `NMParseError` constructors to the `NoMenu`
   data type.
 - Almost all places that evaluated to `Maybe a` were changed to
   `Either NoMenu a` to allow for error messages to bubble up to
   the logger.
 - Added log files to .gitignore.