### PR TITLE
Fixed Linsen parsing error.

### DIFF
--- a/src/Model/Karen.hs
+++ b/src/Model/Karen.hs
@@ -15,7 +15,11 @@ import           Model.Types                              ( Menu
                                                           , NoMenu(..)
                                                           , Restaurant(..)
                                                           )
-import           Model.KarenJSON
+import           Model.KarenJSON                          ( parseMenuForDay
+                                                          , parseMenus
+                                                          )
+import           Util                                     ( menusToEitherNoLunch
+                                                          )
 
 -- | Parse a restaurant that Kåren has.
 getKaren :: Day -> ByteString -> Either NoMenu [Menu]
@@ -25,8 +29,6 @@ getKaren weekday rawBS = maybe (Left NoLunch) (pure . pure) =<< first
 
 -- | Parse today's menu for a restaurant that Kåren has.
 getKarenToday :: ByteString -> Either NoMenu [Menu]
-getKarenToday rawBS =
-  first (flip NMParseError rawBS)
-    $   fmap (concat . snd)
-    $   parseEither parseMenus
-    =<< eitherDecode rawBS
+getKarenToday rawBS = menusToEitherNoLunch =<< first
+  (flip NMParseError rawBS)
+  (concat . snd <$> (parseEither parseMenus =<< eitherDecode rawBS))

--- a/src/Model/KarenGraphQLApi.hs
+++ b/src/Model/KarenGraphQLApi.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveGeneric, FlexibleContexts, LambdaCase, OverloadedStrings, QuasiQuotes #-}
+{-# LANGUAGE DeriveAnyClass, DeriveGeneric, FlexibleContexts, OverloadedStrings, QuasiQuotes #-}
 
 module Model.KarenGraphQLApi
   ( fetchAndCreateRestaurant
@@ -57,7 +57,9 @@ import           Model.Types                              ( ClientContext(..)
                                                             )
                                                           )
 
-import           Util                                     ( safeBS )
+import           Util                                     ( menusToEitherNoLunch
+                                                          , safeBS
+                                                          )
 
 apiURL :: String
 apiURL = "https://heimdallprod.azurewebsites.net/graphql"
@@ -186,9 +188,7 @@ fetchMenu lang restaurantUUID day = do
     )
 
   pure
-    $   \case
-          [] -> Left NoLunch
-          xs -> Right xs
+    $   menusToEitherNoLunch
     .   mapMaybe (\m -> Menu (variant m) <$> nameOf lang m)
     =<< (   (app . (toNMParseError &&& parseEither parseResponse))
         =<< (app . (toNMParseError &&& eitherDecode))

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts , LambdaCase #-}
 
 module Util where
 
@@ -58,3 +58,9 @@ safeGetBS = (=<<) safeBS . parseRequest
 -- | Handler for HttpExceptions
 handle' :: IO a -> IO (Either HttpException a)
 handle' = try
+
+-- | Turn a list of Menu into an `Either NoMenu [Menu]`
+menusToEitherNoLunch :: [Menu] -> Either NoMenu [Menu]
+menusToEitherNoLunch = \case
+  [] -> Left NoLunch
+  xs -> Right xs


### PR DESCRIPTION
Now we can handle really interesting input data, like for instance:
```
{"menuDate":"0001-01-01T00:00:00","recipeCategories":null}
```

Which is the data we get from Linsen today.