### PR TITLE
Replace decodeutf8 with decodeUtf8With

### DIFF
--- a/src/Model/Karen.hs
+++ b/src/Model/Karen.hs
@@ -4,16 +4,10 @@ import           Data.Aeson                               ( eitherDecode )
 import           Data.Aeson.Types                         ( parseEither )
 import           Data.ByteString.Lazy                     ( ByteString )
 import           Data.Bifunctor                           ( first )
-import           Data.Maybe                               ( fromMaybe )
-import           Data.Text.Lazy                           ( Text
-                                                          , pack
-                                                          )
-import           Data.Text.Lazy.Encoding                  ( decodeUtf8 )
 import           Data.Thyme                               ( Day )
 
 import           Model.Types                              ( Menu
                                                           , NoMenu(..)
-                                                          , Restaurant(..)
                                                           )
 import           Model.KarenJSON                          ( parseMenuForDay
                                                           , parseMenus

--- a/src/Model/Wijkanders.hs
+++ b/src/Model/Wijkanders.hs
@@ -22,6 +22,9 @@ import           Data.Maybe                               ( fromMaybe
                                                           , isJust
                                                           , mapMaybe
                                                           )
+import           Data.Text.Encoding.Error                 ( ignore )
+import qualified Data.Text.Lazy                as T
+import           Data.Text.Lazy.Encoding                  ( decodeUtf8With )
 import           Data.Thyme                               ( Day
                                                           , _ymdDay
                                                           , gregorian
@@ -35,8 +38,6 @@ import           Lens.Micro.Platform                      ( (%~)
                                                           , view
                                                           )
 import           Safe                                     ( atMay )
-import qualified Data.Text.Lazy                as T
-import           Data.Text.Lazy.Encoding                  ( decodeUtf8 )
 import           Text.HTML.TagSoup                        ( (~==)
                                                           , Tag
                                                           , isTagText
@@ -84,7 +85,7 @@ getWijkanders d =
     >>> mapMaybe ((maybeTagText =<<) . (`atMay` 1))
     >>> map
           (   BL.break (== W8._colon)
-          >>> (decodeUtf8 *** (decodeUtf8 . BL.drop 1))
+          >>> (decodeUtf8With ignore *** (decodeUtf8With ignore . BL.drop 1))
           >>> uncurry Menu
           )
     >>> menusToEitherNoLunch

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts , LambdaCase #-}
+{-# LANGUAGE FlexibleContexts, LambdaCase #-}
 
 module Util where
 
@@ -18,7 +18,6 @@ import           Data.ByteString.Lazy                     ( ByteString )
 import           Data.Text.Lazy                           ( Text
                                                           , pack
                                                           )
-import           Data.Text.Lazy.Encoding                  ( decodeUtf8 )
 import           Network.HTTP.Client                      ( HttpException
                                                           , Request
                                                           , httpLbs
@@ -34,12 +33,6 @@ import           Model.Types                              ( ClientContext(..)
 
 takeNext :: [a] -> [a]
 takeNext = take 1 . drop 1
-
-safeGet
-  :: (MonadIO m, MonadReader ClientContext m, MonadThrow m)
-  => String
-  -> m (Either NoMenu Text)
-safeGet = (fmap . fmap) decodeUtf8 . safeGetBS
 
 safeBS
   :: (MonadIO m, MonadReader ClientContext m, MonadThrow m)


### PR DESCRIPTION
This PR replaces `decodeUtf8` with `decodeUtf8With` where appropriate, it also removes some unused functions and some unused imports. 