### PR TITLE
supervisord.conf: ta bort

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,7 +1,0 @@
-[program:mat]
-command=/usr/home/adam/www/mat.ethnoll.se/.stack-work/install/x86_64-freebsd/lts-2.19/7.8.4/bin/mat-chalmers
-directory=/home/adam/www/mat.ethnoll.se
-stdout_logfile=/home/adam/www/mat.ethnoll.se/stdout.log
-stderr_logfile=/home/adam/www/mat.ethnoll.se/stderr.log
-user=adam
-environment=LANG="en_US.UTF-8",LC_ALL="en_US.UTF-8",LC_LANG="en_US.UTF-8"


### PR DESCRIPTION
Behövs ej längre
...
tror jag? Något kommer säkert gå sönder O_o

RANT:
>20:26 <D> <u3836> > ethnoll.se
>20:26 <D> <u3836> > freebsd
>20:26 <D> <u3836> > hårdkodad användare

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>