### PR TITLE
Removed the split build and exec phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haskell:8.10 AS build
+FROM haskell:8.10
 RUN mkdir -p /app/user
 WORKDIR /app/user
 COPY stack.yaml *.cabal ./
@@ -9,7 +9,6 @@ RUN stack build --dependencies-only
 COPY . /app/user
 RUN stack install
 
-FROM ubuntu:latest AS exec
 ENV LANG C.UTF-8
 CMD /root/.local/bin/mat-chalmers
 EXPOSE 5007


### PR DESCRIPTION
For some weird reason, running `docker-compose up` with a split dockerfile like before, makes only the exec part happen. Without it however, it works as intended.