### PR TITLE
chore: remove Express restaurant because it's gone in reality

### DIFF
--- a/src/Model.hs
+++ b/src/Model.hs
@@ -98,9 +98,6 @@ update = do
     [ karenR "K\229rrestaurangen"
              "karrestaurangen"
              "21f31565-5c2b-4b47-d2a1-08d558129279"
-    , karenR "Express Johanneberg"
-             "johanneberg-express"
-             "3d519481-1667-4cad-d2a3-08d558129279"
     , karenR "S.M.A.K." "smak" "3ac68e11-bcee-425e-d2a8-08d558129279"
     , karenR "L's Kitchen" "ls-kitchen" "c74da2cf-aa1a-4d3a-9ba6-08d5569587a1"
     , fmap

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,24 +24,6 @@ testFun expected = either
 
 main :: IO ()
 main = hspec $ do
-  describe "hasDate"
-    $ it "parses a legit date" (hasDate (BL8.pack "2/1") @?= Just (1, 2))
-  describe "The Karen Express" $ it
-    "parses a blob of JSON without error"
-    ( testFun
-        [ Menu (T.pack "Express")
-               (T.pack "Kycklinggryta, persilja, senap & kokt potatis")
-        , Menu (T.pack "Express - Vegan")
-               (T.pack "Vegetariska biffar, persiljekr\228m & potatismos")
-        ]
-
-    $ parse
-        "Swedish"
-        (BL8.pack
-          "{\"data\":{\"dishOccurrencesByTimeRange\":[{\"displayNames\":[{\"name\":\"Kycklinggryta, persilja, senap & kokt potatis\",\"categoryName\":\"Swedish\"},{\"name\":\"Chicken stew, parsley, mustard & boiled potatoes\",\"categoryName\":\"English\"}],\"startDate\":\"9/9/2019 12:00:00 AM\",\"dishType\":{\"name\":\"Express\"},\"dish\":{\"name\":\"Kycklinggryta, aubergin, zucchini, tomat & rostad potatis\"}},{\"displayNames\":[{\"name\":\"Vegetariska biffar, persiljekr\195\164m & potatismos\",\"categoryName\":\"Swedish\"},{\"name\":\"Vegetarian patties, parsley cream & mashed potatoes\",\"categoryName\":\"English\"}],\"startDate\":\"9/9/2019 12:00:00 AM\",\"dishType\":{\"name\":\"Express - Vegan\"},\"dish\":{\"name\":\"Vegetariska biffar, majonn\195\164s & potatispur\195\169\"}}]}}\n"
-        )
-    )
-
   describe "The Wijkander's"
     $ it "Parses two blobs of HTML correctly on fridays"
     $ do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -24,6 +24,28 @@ testFun expected = either
 
 main :: IO ()
 main = hspec $ do
+  describe "hasDate"
+    $ it "parses a legit date" (hasDate (BL8.pack "2/1") @?= Just (1, 2))
+  describe "The Karen Express" $ it
+    "parses a blob of JSON without error"
+    ( testFun
+        [ Menu
+            (T.pack "Street food")
+            (T.pack "Chicken africana, banan, mango raja, ris")
+        , Menu
+            (T.pack "Greens")
+            (T.pack "Indisklinsgryta, zucchini, aubergin, ingef\228ra, koriander, ris")
+        , Menu
+            (T.pack "Nordic")
+            (T.pack "F\228rskost bakad sej, vitvinss\229s, broccoli, potatis")
+        ]
+    $ parse
+        "Swedish"
+        (BL8.pack
+          "{\"data\":{\"dishOccurrencesByTimeRange\":[{\"displayNames\":[{\"name\":\"Chicken africana, banan, mango raja, ris\",\"categoryName\":\"Swedish\"},{\"name\":\"Chicken africana, banana, mango raja, rice\",\"categoryName\":\"English\"}],\"startDate\":\"09/25/2023 00:00:00\",\"dishType\":{\"name\":\"Street food\"},\"dish\":{\"name\":\"Kyckling, het paprikas\195\165s & ris\"}},{\"displayNames\":[{\"name\":\"Indian linseed stew, zucchini, aubergine, ginger, coriander\",\"categoryName\":\"English\"},{\"name\":\"Indisklinsgryta, zucchini, aubergin, ingef\195\164ra, koriander, ris\",\"categoryName\":\"Swedish\"}],\"startDate\":\"09/25/2023 00:00:00\",\"dishType\":{\"name\":\"Greens\"},\"dish\":{\"name\":\"Vegan, pasta, linsbolognese\"}},{\"displayNames\":[{\"name\":\"F\195\164rskost bakad sej, vitvinss\195\165s, broccoli, potatis\",\"categoryName\":\"Swedish\"},{\"name\":\"Cream cheese baked saithe, whitewine sauce, broccoli, potatoes\",\"categoryName\":\"English\"}],\"startDate\":\"09/25/2023 00:00:00\",\"dishType\":{\"name\":\"Nordic\"},\"dish\":{\"name\":\"Bakad fisk, vitvinss\195\165s, potatispur\195\169\"}}]}}\n"
+        )
+    )
+
   describe "The Wijkander's"
     $ it "Parses two blobs of HTML correctly on fridays"
     $ do


### PR DESCRIPTION
It's good if mat reflects reality. This commit makes mat more reality reflective and fixes #110.

Thank you Rembane for the above commit message.