### PR TITLE
Add invisible space

### DIFF
--- a/src/View.hs
+++ b/src/View.hs
@@ -58,6 +58,7 @@ renderMenu :: Menu -> Html ()
 renderMenu (Menu lunch spec) = li_
   (do
     h3_ (toHtml lunch)
+    span_ [class_ "invisible-space"] " "
     toHtml spec
   )
 

--- a/static/style.css
+++ b/static/style.css
@@ -37,6 +37,10 @@ h3 {
   font-weight: bold;
   color: #bd3613;
 }
+.invisible-space {
+  width: 0px;
+  font-size: 0px;
+}
 p {
   font-size: 10vh;
 }


### PR DESCRIPTION
Currently, when copying menu items from the web page the header of each item is joined with the contents. This PR adds a space between the two, without making any visible changes.