### PR TITLE
Add `cabal update` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Lunch menus on Chalmers in Gothenburg. Issues and pull requests welcome.
 ```
 git clone https://github.com/dtekcth/mat-chalmers.git
 cd mat-chalmers
+cabal update
 cabal build         # (or cabal run)
 ```
 


### PR DESCRIPTION
This should make cabal happier and not bother the developer with demands
of updating the cabal cache by running `cabal update`.
