### PR TITLE
Fix exception handling during requests

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   check:
     name: Compile and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: haskell-actions/setup@v2

--- a/mat-chalmers.cabal
+++ b/mat-chalmers.cabal
@@ -31,7 +31,8 @@ library
                , attoparsec >= 0.14.4 && < 0.15
                , base >=4.18.2.0 && < 5.0
                , bytestring >=0.11 && < 0.13
-               , effectful >= 2.3.1.0 && < 3.0.0.0
+               , effectful >= 2.6.1.0 && < 3.0.0.0
+               , effectful-core >= 2.6.1.0 && < 3.0.0.0
                , log-effectful >= 1.0.0.0 && < 2.0.0.0
                , heredoc >= 0.2.0.0 && < 0.3
                , microlens-platform >= 0.4.3.5 && < 0.5
@@ -55,6 +56,7 @@ executable mat-chalmers
                , base
                , bytestring
                , effectful
+               , effectful-core
                , log-effectful
                , log-base >= 0.12.0.0 && < 1.0.0.0
                , file-embed

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -132,10 +132,14 @@ update = do
     , fetchAndCreateLinsen day'
     ]
 
-  for_ rest $ \r -> case menu r of
-    Left e@(NMParseError _ _) ->
-      asks _cLogPath >>= \path ->
-      liftIO getCurrentTime >>=
-      liftIO . flip writeFile (show e) . flip (printf "%s/%s%s.txt" path) (name r) . show
-    _ -> pure ()
+  for_ rest $ \r ->
+    let f e = asks _cLogPath >>= \path ->
+              liftIO getCurrentTime >>=
+              liftIO . flip writeFile (show e) . flip (printf "%s/%s%s.txt" path) (name r) . show
+    in case menu r of
+        Left e@(NMParseError _ _) -> f e
+        Left e@(NMExceptionRaised _) -> f e
+        Left NoLunch -> pure ()
+        Right _ -> pure ()
+
   return (View rest textday d)

--- a/src/Model/Karen.hs
+++ b/src/Model/Karen.hs
@@ -30,6 +30,7 @@ import           Data.Thyme.Calendar                      ( Day
 import           Effectful                                ( (:>)
                                                           , Eff
                                                           )
+import           Effectful.Exception                      ( handleIO )
 import           Effectful.Wreq                           ( Wreq
                                                           , asValue
                                                           , post
@@ -148,4 +149,6 @@ fetchAndCreateRestaurant day title tag uuid =
       <> "/"
       <> uuid
       )
-    <$> fmap (parse "Swedish") (fetch (unpack uuid) day)
+    <$> handleIO
+          (const . pure $ Left NMAccessError)
+          (parse "Swedish" <$> fetch (unpack uuid) day)

--- a/src/Model/Karen.hs
+++ b/src/Model/Karen.hs
@@ -30,7 +30,7 @@ import           Data.Thyme.Calendar                      ( Day
 import           Effectful                                ( (:>)
                                                           , Eff
                                                           )
-import           Effectful.Exception                      ( handleIO )
+import           Effectful.Exception                      ( handle )
 import           Effectful.Wreq                           ( Wreq
                                                           , asValue
                                                           , post
@@ -45,7 +45,9 @@ import           Model.Types                              ( NoMenu(..)
                                                             )
                                                           )
 import           Util                                     ( menusToEitherNoLunch
-                                                          , (^.^) )
+                                                          , networkExceptionHandler
+                                                          , (^.^)
+                                                          )
 
 
 -- brittany-disable-next-binding
@@ -149,6 +151,5 @@ fetchAndCreateRestaurant day title tag uuid =
       <> "/"
       <> uuid
       )
-    <$> handleIO
-          (const . pure $ Left NMAccessError)
+    <$> handle networkExceptionHandler
           (parse "Swedish" <$> fetch (unpack uuid) day)

--- a/src/Model/Linsen.hs
+++ b/src/Model/Linsen.hs
@@ -18,7 +18,8 @@ import           Data.Aeson                               ( (.:)
                                                           , (.!=)
                                                           , withObject
                                                           , Object
-                                                          , Value )
+                                                          , Value
+                                                          )
 import           Data.Aeson.Types                         ( Parser
                                                           , parseEither )
 import           Data.Bifunctor                           ( first )
@@ -37,6 +38,7 @@ import           Data.Thyme.Calendar.WeekDate             ( weekDate
 import           Effectful                                ( (:>)
                                                           , Eff
                                                           )
+import           Effectful.Exception                      ( handleIO )
 import           Lens.Micro.Platform                      ( (^.) )
 import           Effectful.Wreq                           ( Wreq
                                                           , asValue
@@ -136,4 +138,6 @@ fetchAndCreateLinsen day =
   Restaurant
       "Café Linsen"
       "https://cafe-linsen.se/#menu"
-    <$> fmap (parse day) fetch
+    <$> handleIO
+          (const . pure $ Left NMAccessError)
+          (parse day <$> fetch)

--- a/src/Model/Linsen.hs
+++ b/src/Model/Linsen.hs
@@ -38,7 +38,7 @@ import           Data.Thyme.Calendar.WeekDate             ( weekDate
 import           Effectful                                ( (:>)
                                                           , Eff
                                                           )
-import           Effectful.Exception                      ( handleIO )
+import           Effectful.Exception                      ( handle )
 import           Lens.Micro.Platform                      ( (^.) )
 import           Effectful.Wreq                           ( Wreq
                                                           , asValue
@@ -49,8 +49,10 @@ import           Model.Types                              ( NoMenu(..)
                                                           , Restaurant ( Restaurant ) )
 import           Prelude                       hiding     ( all )
 import           Util                                     ( menusToEitherNoLunch
+                                                          , networkExceptionHandler
                                                           , swedishTimeLocale
-                                                          , (^.^) )
+                                                          , (^.^)
+                                                          )
 
 
 pattern MeatDish, FishDish, VegDish :: Integer
@@ -138,6 +140,5 @@ fetchAndCreateLinsen day =
   Restaurant
       "Café Linsen"
       "https://cafe-linsen.se/#menu"
-    <$> handleIO
-          (const . pure $ Left NMAccessError)
+    <$> handle networkExceptionHandler
           (parse day <$> fetch)

--- a/src/Model/Types.hs
+++ b/src/Model/Types.hs
@@ -26,7 +26,7 @@ data Restaurant = Restaurant
 data NoMenu
   = NoLunch
   | NMParseError String ByteString -- ^ The parse error. The string we tried to parse.
-  | NMAccessError
+  | NMExceptionRaised String -- ^ The exception raised.
   deriving (Eq, Show)
 
 -- | Menu of a restaurant.

--- a/src/Model/Types.hs
+++ b/src/Model/Types.hs
@@ -26,6 +26,7 @@ data Restaurant = Restaurant
 data NoMenu
   = NoLunch
   | NMParseError String ByteString -- ^ The parse error. The string we tried to parse.
+  | NMAccessError
   deriving (Eq, Show)
 
 -- | Menu of a restaurant.

--- a/src/Model/Wijkanders.hs
+++ b/src/Model/Wijkanders.hs
@@ -41,7 +41,7 @@ import qualified Data.Word8                    as W8
 import           Effectful                                ( (:>)
                                                           , Eff
                                                           )
-import           Effectful.Exception                      ( handleIO )
+import           Effectful.Exception                      ( handle )
 import           Lens.Micro.Platform                      ( view )
 import           Effectful.Wreq                           ( Wreq
                                                           , get
@@ -60,8 +60,10 @@ import           Model.Types                              ( Menu(..)
                                                           , NoMenu(..)
                                                           , Restaurant (Restaurant)
                                                           )
-import           Util                                     ( removeWhitespaceTags
-                                                          , (^.^) )
+import           Util                                     ( networkExceptionHandler
+                                                          , removeWhitespaceTags
+                                                          , (^.^)
+                                                          )
 
 wijkandersAPIURL :: String
 wijkandersAPIURL = "https://www.wijkanders.se/restaurangen"
@@ -133,6 +135,5 @@ fetchAndCreateWijkanders day =
   Restaurant
       "Wijkanders"
       (pack wijkandersAPIURL)
-  <$> handleIO
-        (const . pure $ Left NMAccessError)
+  <$> handle networkExceptionHandler
         (get wijkandersAPIURL >>= (^.^ responseBody) <&> getWijkanders day)

--- a/src/Model/Wijkanders.hs
+++ b/src/Model/Wijkanders.hs
@@ -41,6 +41,7 @@ import qualified Data.Word8                    as W8
 import           Effectful                                ( (:>)
                                                           , Eff
                                                           )
+import           Effectful.Exception                      ( handleIO )
 import           Lens.Micro.Platform                      ( view )
 import           Effectful.Wreq                           ( Wreq
                                                           , get
@@ -129,5 +130,9 @@ fetchAndCreateWijkanders
   => Day
   -> Eff es Restaurant
 fetchAndCreateWijkanders day =
-  get wijkandersAPIURL >>= (^.^ responseBody) <&>
-    Restaurant "Wijkanders" (pack wijkandersAPIURL) . getWijkanders day
+  Restaurant
+      "Wijkanders"
+      (pack wijkandersAPIURL)
+  <$> handleIO
+        (const . pure $ Left NMAccessError)
+        (get wijkandersAPIURL >>= (^.^ responseBody) <&> getWijkanders day)

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -7,6 +7,8 @@ import qualified Data.ByteString.Lazy          as BL
 import qualified Data.Word8                    as W8
 
 import           Data.Thyme                               ( TimeLocale (..) )
+import           Effectful                                ( Eff )
+import           Effectful.Exception                      ( SomeException )
 import           Text.HTML.TagSoup                        ( Tag
                                                           , isTagText
                                                           )
@@ -68,3 +70,7 @@ swedishTimeLocale = TimeLocale
         , time12Fmt = "%I:%M:%S %p"
         , knownTimeZones = []
         }
+
+-- If something raises an exception while fetching and parsing data, default handler for saving said exception.
+networkExceptionHandler :: (SomeException -> Eff es (Either NoMenu [Menu]))
+networkExceptionHandler = pure . Left . NMExceptionRaised . show


### PR DESCRIPTION
When issuing requests to servers for the menu, they can raise an exception. This adds a check for that, and properly logs if an exception was raised during fetching of menus.