### PR TITLE
Make empty menu an error

### DIFF
--- a/src/Model/Karen.hs
+++ b/src/Model/Karen.hs
@@ -21,6 +21,7 @@ import           Data.Aeson.Types                         ( Parser
 import           Data.Bifunctor                           ( first )
 import qualified Data.ByteString.Lazy.Char8    as BL8
 import           Data.Foldable                            ( find )
+import           Data.List.NonEmpty                       ( NonEmpty )
 import           Data.Text.Lazy                           ( Text
                                                           , unpack
                                                           )
@@ -99,9 +100,9 @@ fetch restaurantUUID day =
 
 -- | Parses menus from Kåren's GraphQL API.
 parse
-  :: Language             -- ^ Language
-  -> Value                -- ^ JSON result from `fetch`
-  -> Either NoMenu [Menu] -- ^ Either list of parsed `Menu`s or `NoMenu` error
+  :: Language                      -- ^ Language
+  -> Value                         -- ^ JSON result from `fetch`
+  -> Either NoMenu (NonEmpty Menu) -- ^ Either non-empty list of parsed `Menu`s or `NoMenu` error
 parse lang =
     failWithNoMenu
       (parseEither

--- a/src/Model/Linsen.hs
+++ b/src/Model/Linsen.hs
@@ -27,6 +27,7 @@ import qualified Data.ByteString.Lazy.Char8    as BL8
 import           Data.Char                                ( isSpace )
 import           Data.Functor                             ( (<&>) )
 import           Data.List.Extra                          ( (!?) )
+import           Data.List.NonEmpty                       ( NonEmpty )
 import           Data.Text.Lazy                           ( Text
                                                           , all
                                                           , replace
@@ -65,9 +66,9 @@ fetch =
   get "https://cafe-linsen.se/api/menu" >>= asValue >>= (^.^ responseBody)
 
 parse
-  :: Day                  -- ^ Day to parse
-  -> Value                -- ^ JSON result from `fetch`
-  -> Either NoMenu [Menu] -- ^ Either list of parsed `Menu`s or `NoMenu` error
+  :: Day                           -- ^ Day to parse
+  -> Value                         -- ^ JSON result from `fetch`
+  -> Either NoMenu (NonEmpty Menu) -- ^ Either non-empty list of parsed `Menu`s or `NoMenu` error
 parse day =
     failWithNoMenu
       (parseEither

--- a/src/Model/Types.hs
+++ b/src/Model/Types.hs
@@ -5,6 +5,7 @@
 module Model.Types where
 
 import           Data.ByteString.Lazy                     ( ByteString )
+import           Data.List.NonEmpty                       ( NonEmpty )
 import           Data.Text.Lazy                           ( Text )
 import           Data.Thyme                               ( LocalTime )
 import           Lens.Micro.Platform
@@ -20,7 +21,7 @@ data View = View
 data Restaurant = Restaurant
   { name :: Text
   , url  :: Text
-  , menu :: Either NoMenu [Menu]
+  , menu :: Either NoMenu (NonEmpty Menu)
   } deriving (Show)
 
 data NoMenu

--- a/src/Model/Wijkanders.hs
+++ b/src/Model/Wijkanders.hs
@@ -24,8 +24,7 @@ import qualified Data.ByteString.Char8         as B8
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.ByteString.Lazy.Char8    as BL8
 import           Data.Functor                             ( (<&>) )
-import           Data.List.NonEmpty                       ( NonEmpty )
-import qualified Data.List.NonEmpty            as NE
+import           Data.List.NonEmpty                       ( NonEmpty(..) )
 import           Data.Maybe                               ( mapMaybe )
 import           Data.Text.Encoding.Error                 ( ignore )
 import           Data.Text.Encoding                       ( encodeUtf8 )
@@ -127,7 +126,7 @@ getWijkanders d b = go b
               )
         >>> \case
               [] -> Left (NMParseError "Wijkanders failed" b)
-              xs -> (Right . NE.fromList) xs
+              (x:xs) -> Right (x :| xs)
 
 fetchAndCreateWijkanders
   :: (Wreq :> es)

--- a/src/Model/Wijkanders.hs
+++ b/src/Model/Wijkanders.hs
@@ -24,6 +24,8 @@ import qualified Data.ByteString.Char8         as B8
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.ByteString.Lazy.Char8    as BL8
 import           Data.Functor                             ( (<&>) )
+import           Data.List.NonEmpty                       ( NonEmpty )
+import qualified Data.List.NonEmpty            as NE
 import           Data.Maybe                               ( mapMaybe )
 import           Data.Text.Encoding.Error                 ( ignore )
 import           Data.Text.Encoding                       ( encodeUtf8 )
@@ -78,11 +80,11 @@ hasDate = maybeResult . parse (flip (,) <$> parseDay <*> parseMonth)
   parseMonth    = string (encodeUtf8 "/") *> integerParser
   integerParser = fmap (read . B8.unpack) (takeWhile1 W8.isDigit)
 
--- | getWijkanders will either give you a list of menus or NoLunch.
+-- | getWijkanders will either give you a non-empty list of menus or NoLunch.
 -- At the moment there is no way to catch parsing errors.
 -- We also bet all our money on red 17, and that the maintainers of
 -- Wijkander's homepage keep writing dd/mm for every day.
-getWijkanders :: Day -> ByteString -> Either NoMenu [Menu]
+getWijkanders :: Day -> ByteString -> Either NoMenu (NonEmpty Menu)
 getWijkanders d b = go b
  where
   go = parseTags
@@ -106,7 +108,7 @@ getWijkanders d b = go b
       [] -> Left NoLunch -- No lunch in the case that we cannot parse the date
       a  -> parseWijkanderLunch a
 
-  parseWijkanderLunch :: [Tag ByteString] -> Either NoMenu [Menu]
+  parseWijkanderLunch :: [Tag ByteString] -> Either NoMenu (NonEmpty Menu)
   parseWijkanderLunch =
         -- The heading is of no use to us.
         drop 1
@@ -125,7 +127,7 @@ getWijkanders d b = go b
               )
         >>> \case
               [] -> Left (NMParseError "Wijkanders failed" b)
-              xs -> Right xs
+              xs -> (Right . NE.fromList) xs
 
 fetchAndCreateWijkanders
   :: (Wreq :> es)

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -6,8 +6,7 @@ import           Data.ByteString.Lazy                     ( ByteString )
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.Word8                    as W8
 
-import           Data.List.NonEmpty                       ( NonEmpty )
-import qualified Data.List.NonEmpty            as NE
+import           Data.List.NonEmpty                       ( NonEmpty(..) )
 import           Data.Thyme                               ( TimeLocale (..) )
 import           Effectful                                ( Eff )
 import           Effectful.Exception                      ( SomeException )
@@ -27,7 +26,7 @@ takeNext = take 1 . drop 1
 menusToEitherNoLunch :: [Menu] -> Either NoMenu (NonEmpty Menu)
 menusToEitherNoLunch = \case
   [] -> Left NoLunch
-  xs -> (Right . NE.fromList) xs
+  (x:xs) -> Right (x :| xs)
 
 -- | Remove text tags that only contain whitespace.
 removeWhitespaceTags :: [Tag ByteString] -> [Tag ByteString]

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -6,6 +6,8 @@ import           Data.ByteString.Lazy                     ( ByteString )
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.Word8                    as W8
 
+import           Data.List.NonEmpty                       ( NonEmpty )
+import qualified Data.List.NonEmpty            as NE
 import           Data.Thyme                               ( TimeLocale (..) )
 import           Effectful                                ( Eff )
 import           Effectful.Exception                      ( SomeException )
@@ -22,11 +24,10 @@ import           Lens.Micro.Platform
 takeNext :: [a] -> [a]
 takeNext = take 1 . drop 1
 
--- | Turn a list of Menu into an `Either NoMenu [Menu]`
-menusToEitherNoLunch :: [Menu] -> Either NoMenu [Menu]
+menusToEitherNoLunch :: [Menu] -> Either NoMenu (NonEmpty Menu)
 menusToEitherNoLunch = \case
   [] -> Left NoLunch
-  xs -> Right xs
+  xs -> (Right . NE.fromList) xs
 
 -- | Remove text tags that only contain whitespace.
 removeWhitespaceTags :: [Tag ByteString] -> [Tag ByteString]
@@ -72,5 +73,5 @@ swedishTimeLocale = TimeLocale
         }
 
 -- If something raises an exception while fetching and parsing data, default handler for saving said exception.
-networkExceptionHandler :: (SomeException -> Eff es (Either NoMenu [Menu]))
+networkExceptionHandler :: (SomeException -> Eff es (Either NoMenu (NonEmpty Menu)))
 networkExceptionHandler = pure . Left . NMExceptionRaised . show

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,6 +3,8 @@ import qualified Data.ByteString.Lazy          as BL
 import qualified Data.ByteString.Lazy.Char8    as BL8
 import qualified Data.Text.Lazy                as T
 import           Data.Aeson                               ( decode )
+import           Data.List.NonEmpty                       ( NonEmpty )
+import qualified Data.List.NonEmpty            as NE
 import           Data.Maybe                               ( fromJust )
 import           Data.Thyme.Time.Core                     ( fromGregorian )
 import           Model.Karen                              ( parse )
@@ -21,7 +23,7 @@ import           Test.HUnit                               ( (@?=)
                                                           , assertFailure
                                                           )
 
-testFun :: Either NoMenu [Menu] -> Either NoMenu [Menu] -> IO ()
+testFun :: Either NoMenu (NonEmpty Menu) -> Either NoMenu (NonEmpty Menu) -> IO ()
 testFun = \case
     Right e ->
       either
@@ -43,7 +45,7 @@ main = hspec $ do
   describe "The Karen Express" $ it
     "parses a blob of JSON without error"
     ( testFun
-        (Right [ Menu
+        ((Right . NE.fromList) [ Menu
             (T.pack "Street food")
             (T.pack "Chicken africana, banan, mango raja, ris")
         , Menu
@@ -63,7 +65,7 @@ main = hspec $ do
   describe "The Karen Express" $ it
     "parses a blob of JSON without error, but it has an dish without dishType"
     ( testFun
-        (Right [ Menu
+        ((Right . NE.fromList) [ Menu
             (T.pack "Unknown menu")
             (T.pack "Fläskfilé, svampsås & rostad klyftpotatis")
         , Menu
@@ -87,7 +89,7 @@ main = hspec $ do
     (do
       s1 <- BL.readFile "test/linsen1.json"
       testFun
-        (Right [ Menu
+        ((Right . NE.fromList) [ Menu
             (T.pack "Raggmunk.")
             (T.pack "Stekt Fläsk, Lingon, Persilja.")
         , Menu
@@ -126,7 +128,7 @@ main = hspec $ do
     "parses a blob of JSON without error, with a new layout"
     (do
       s4 <- BL.readFile "test/linsen4.json"
-      testFun (Right [ Menu
+      testFun ((Right . NE.fromList) [ Menu
             (T.pack "Lammfärsbiffar.")
             (T.pack "Ratatouille, Tzatziki, Rosmarin, Klyftpotatis.")
         , Menu
@@ -146,7 +148,7 @@ main = hspec $ do
     $ do
         s1 <- BL.readFile "test/190517 wijkanders.html"
         testFun
-          (Right [ Menu
+          ((Right . NE.fromList) [ Menu
             (T.pack "Fisk")
             (T.pack
               "Havets Wallenbergare, kallpressad rapsolja, ärtor, dill & potatismos"
@@ -160,7 +162,7 @@ main = hspec $ do
           (getWijkanders (fromGregorian 2019 05 17) s1)
         s2 <- BL.readFile "test/190913 wijkanders.html"
         testFun
-          (Right [ Menu
+          ((Right . NE.fromList) [ Menu
             (T.pack "Vegetarisk ")
             (T.pack
               "Pasta, svamp, grädde, citron, grana padano & rotfruktschips"


### PR DESCRIPTION
Before this change the empty menu could either be represented by `Left NoLunch` or `Right []`, which introduces an unnecessary ambiguity. This commit does not let a menu be empty by using the excellent `NonEmpty` type, and then doing all the necessary changes in the code base.